### PR TITLE
Add register module and load hook

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,0 +1,25 @@
+import process from "node:process";
+import { transform } from "esbuild";
+
+const tsExtensionsRegex = /\.(ts|mts)$/;
+
+export async function load(url, context, nextLoad) {
+  if (tsExtensionsRegex.test(url)) {
+    const { source } = await nextLoad(url, { ...context, format: "module" });
+
+    const transformedSource = await transform(source.toString(), {
+      target: "esnext",
+      loader: "ts",
+      sourcemap: "inline",
+      sourcesContent: (process.env.NODE_ENV ?? "development") !== "production",
+    });
+
+    return {
+      format: "module",
+      shortCircuit: true,
+      source: transformedSource.code,
+    };
+  }
+
+  return nextLoad(url);
+}

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { transform } from "esbuild";
 
 const tsExtensionsRegex = /\.(ts|mts)$/;
@@ -10,7 +11,9 @@ export async function load(url, context, nextLoad) {
     const transformedSource = await transform(source.toString(), {
       target: "esnext",
       loader: "ts",
+      tsconfigRaw: `{"compilerOptions":{"verbatimModuleSyntax":true}}`,
       sourcemap: "inline",
+      sourcefile: fileURLToPath(url),
       sourcesContent: (process.env.NODE_ENV ?? "development") !== "production",
     });
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,8 @@
+import process from "node:process";
+import { register } from "node:module";
+
+if ("setSourceMapsEnabled" in process) {
+  process.setSourceMapsEnabled(true);
+}
+
+register("./hooks.js", import.meta.url);


### PR DESCRIPTION
- Add load hook that transforms es modules written in typescript via esbuild
- Esbuild should only handle the typescript -> javascript conversion. No other transformations/transpilations should occur. This is why target is set to esnext and verbatimModuleSyntax is enabled in tsconfigRaw
- Sourcemaps for Node.js are enabled in the register module. During the transform, esbuild adds the source code to the sourcemap so that the code is usable with a debugger. In production mode, the source code is not added. The sourcemap is, however, still useful to get proper stack traces.