### PR TITLE
Add basic tests for js default nextLoad

### DIFF
--- a/tests/js/commonjs/defaultExport.js
+++ b/tests/js/commonjs/defaultExport.js
@@ -1,0 +1,8 @@
+Object.defineProperty(exports, "__esModule", { value: true });
+
+function helloWorld() {
+  return "hello world!";
+}
+
+module.exports = helloWorld;
+module.exports.default = helloWorld;

--- a/tests/js/commonjs/package.json
+++ b/tests/js/commonjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/tests/js/helloWorld.js
+++ b/tests/js/helloWorld.js
@@ -1,0 +1,3 @@
+export function helloWorld() {
+  return "hello world!";
+}

--- a/tests/js/js.test.js
+++ b/tests/js/js.test.js
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+await import("#tsxfm");
+
+describe("js default nextLoad", async () => {
+  it("handles hello world javascript function from ES module", async () => {
+    const { helloWorld } = await import("./helloWorld.js");
+
+    assert.equal(helloWorld(), "hello world!");
+  });
+
+  it("handles CommonJS module with simulated default export", async () => {
+    const { default: helloWorld } = await import("./commonjs/defaultExport.js");
+
+    assert.equal(helloWorld(), "hello world!");
+  });
+});

--- a/tests/ts/ts.test.js
+++ b/tests/ts/ts.test.js
@@ -53,7 +53,7 @@ describe("ts transform", async () => {
     assert.equal(subpathWithTsExt(), "hello world!");
   });
 
-  it("handles imports with search params", async () => {
+  it("transforms imports with search params", async () => {
     // @ts-expect-error TypeScript 5.2 does not support this even though Node.js does
     const { searchParams } = await import("./searchParams.js?hello=world");
 


### PR DESCRIPTION
Add first couple of tests to make sure that the default nextLoad keeps handling imports from ESM and CommonJS JavaScript modules.